### PR TITLE
Use apt preferences instead of dpkg holds

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,16 +5,18 @@ docker_service_state: started
 docker_restart_handler_state: restarted
 
 # package options
-#docker_package_dpkg_selection: hold
 docker_package_state: present
 docker_package_policy_rc_d: 101
 
 docker_packages:
   - docker-ce
   - docker-ce-cli
-#docker_packages_version: "5:24.0.1-1~ubuntu.20.04~focal"
-docker_containerd_package: containerd.io
-#docker_containerd_package_version: "1.6.21-1"
+#docker_package_version: "5:24.0.*"
+docker_package_pin_priority: 990
+docker_containerd_packages:
+  - containerd.io
+#docker_containerd_package_version: "1.6.*"
+docker_containerd_package_pin_priority: 990
 
 # stable, test or nightly
 docker_release_channel: stable

--- a/molecule/default/inventory/group_vars/all.yml
+++ b/molecule/default/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-docker_package_dpkg_selection: hold
+docker_package_version: "5:24.0.7*"
 
 docker_daemon_config:
   live-restore: false

--- a/molecule/default/inventory/host_vars/instance.yml
+++ b/molecule/default/inventory/host_vars/instance.yml
@@ -1,4 +1,6 @@
 ---
+docker_containerd_package_version: "1.6.24*"
+
 docker_host_daemon_config:
   log-opts:
     max-file: "4"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -10,6 +10,22 @@
       changed_when: false
       failed_when: result.stat.isreg is not defined or not result.stat.isreg
 
+    - name: Ensure specified Docker version is installed
+      ansible.builtin.command: dpkg-query -f '${Version}' -W docker-ce
+      register: result
+      changed_when: false
+      failed_when: >-
+        result.rc != 0 or
+        result.stdout is not match("5:24\.0\.7")
+
+    - name: Ensure specified containerd version is installed
+      ansible.builtin.command: dpkg-query -f '${Version}' -W containerd.io
+      register: result
+      changed_when: false
+      failed_when: >-
+        result.rc != 0 or
+        result.stdout is not match("1\.6\.24")
+
     - name: Ensure Docker is running
       ansible.builtin.service:
         name: Docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,8 @@
 - name: Add Docker repository
   ansible.builtin.apt_repository:
     repo: >-
-        deb [arch={{ docker_deb_architecture[ansible_architecture] }} signed-by={{ docker_repository_key_path }}]
+        deb [arch={{ docker_deb_architecture[ansible_architecture] }}
+        signed-by={{ docker_repository_key_path }}]
         https://download.docker.com/linux/{{ ansible_distribution | lower }}
         {{ ansible_distribution_release }}
         {{ docker_release_channel }}
@@ -37,29 +38,18 @@
     state: present
     update_cache: true
 
+- name: Install Docker apt preferences
+  ansible.builtin.template:
+    src: etc/apt/preferences.d/99-ansible-docker.j2
+    dest: /etc/apt/preferences.d/99-ansible-docker
+    mode: "0644"
+
 - name: Install Docker packages
   ansible.builtin.apt:
-    name: "{{ _docker_packages | flatten }}"
+    name: "{{ docker_packages + docker_containerd_packages }}"
     state: "{{ docker_package_state }}"
     policy_rc_d: "{{ docker_package_policy_rc_d }}"
   ignore_errors: "{{ ansible_check_mode }}"
-  vars:
-    _docker_packages:
-      - >-
-        {{ (docker_packages | product(['=' + docker_packages_version]) | map('join'))
-             if (docker_packages_version | d())
-             else docker_packages }}
-      - >-
-        {{ '{}={}'.format(docker_containerd_package, docker_containerd_package_version)
-             if (docker_containerd_package_version | d())
-             else docker_containerd_package }}
-
-- name: Set Docker package dpkg selection states
-  ansible.builtin.dpkg_selections:
-    name: "{{ item }}"
-    selection: "{{ docker_package_dpkg_selection }}"
-  loop: "{{ [docker_packages, docker_containerd_package] | flatten }}"
-  when: docker_package_dpkg_selection | d()
 
 - name: Create /etc/docker directory
   ansible.builtin.file:

--- a/templates/etc/apt/preferences.d/99-ansible-docker.j2
+++ b/templates/etc/apt/preferences.d/99-ansible-docker.j2
@@ -1,0 +1,14 @@
+#jinja2: trim_blocks: True, lstrip_blocks: True
+# {{ ansible_managed }}
+{% if docker_package_version|d() %}
+
+Package: {{ docker_pinned_packages | join(' ') }}
+Pin: version {{ docker_package_version }}
+Pin-Priority: {{ docker_package_pin_priority }}
+{% endif %}
+{% if docker_containerd_package_version|d() %}
+
+Package: {{ docker_containerd_pinned_packages | join(' ') }}
+Pin: version {{ docker_containerd_package_version }}
+Pin-Priority: {{ docker_containerd_package_pin_priority }}
+{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,3 +9,11 @@ docker_deb_architecture:
   ppc64: ppc64el
   s390x: s390x
   x86_64: amd64
+
+docker_pinned_packages:
+  - docker-ce
+  - docker-ce-cli
+  - docker-ce-rootless-extras
+
+docker_containerd_pinned_packages:
+  - containerd.io


### PR DESCRIPTION
Using apt pinning makes it much more straightforward to install as well as upgrade packages to a specified version. The old approach of holding the package after installation was brittle and required the packages to be manually set back to "install" before it was possible to upgrade.