### PR TITLE
CI: Update python/ansible/ubuntu targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
           molecule-plugins[docker]
           # https://github.com/docker/docker-py/issues/3113
           urllib3<2.0
+          # https://github.com/ansible-community/molecule-plugins/issues/256
+          requests<2.32.0
           EOF
           echo "REQS_HASH=$(sha256sum test-requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,23 +60,27 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - ubuntu2404
-    exclude:
-      - python: "3.10"
-        ansible: 11
-      - python: "3.11"
-        ansible: 6
-      - python: "3.12"
-        ansible:
-          - 6
-          - 7
-          - 8
-      - python: "3.13"
-        ansible:
-          - 6
-          - 7
-          - 8
-          - 9
-          - 10
+        exclude:
+          - python: "3.10"
+            ansible: 11
+          - python: "3.11"
+            ansible: 6
+          - python: "3.12"
+            ansible: 6
+          - python: "3.12"
+            ansible: 7
+          - python: "3.12"
+            ansible: 8
+          - python: "3.13"
+            ansible: 6
+          - python: "3.13"
+            ansible: 7
+          - python: "3.13"
+            ansible: 8
+          - python: "3.13"
+            ansible: 9
+          - python: "3.13"
+            ansible: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,23 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - ubuntu2404
+    exclude:
+      - python: "3.10"
+        ansible: 11
+      - python: "3.11"
+        ansible: 6
+      - python: "3.12"
+        ansible:
+          - 6
+          - 7
+          - 8
+      - python: "3.13"
+        ansible:
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,53 +38,33 @@ jobs:
           ansible-lint
 
   test:
-    name: Test (py${{ matrix.python }} ansible${{ matrix.ansible }} ${{ matrix.distro }})
+    name: Test (${{ matrix.distro }})
     runs-on: ubuntu-latest
     needs:
       - lint
     strategy:
       matrix:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        ansible:
-          - 9
-          - 10
-          - 11
         distro:
           - ubuntu2004
           - ubuntu2204
           - ubuntu2404
-        exclude:
-          - python: "3.10"
-            ansible: 11
-          - python: "3.13"
-            ansible: 9
-          - python: "3.13"
-            ansible: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           path: metabrainz.docker
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: '3.x'
 
       - name: Generate test-requirements.txt
         run: |
           cat <<EOF > test-requirements.txt
-          ansible==${{ matrix.ansible }}.*
-          docker==6.*
+          ansible
+          docker
           molecule-plugins[docker]
-          # https://github.com/docker/docker-py/issues/3113
-          urllib3<2.0
-          # https://github.com/ansible-community/molecule-plugins/issues/256
-          #requests<2.32.0
           EOF
           echo "REQS_HASH=$(sha256sum test-requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
 
@@ -92,7 +72,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-py${{ matrix.python }}-ansible${{ matrix.ansible }}-${{ env.REQS_HASH }}
+          key: ${{ runner.os }}-${{ env.REQS_HASH }}
 
       - name: Install test dependencies
         run: pip3 install -r test-requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,19 @@ jobs:
         python:
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
         ansible:
           - 6
           - 7
           - 8
+          - 9
+          - 10
+          - 11
         distro:
           - ubuntu2004
           - ubuntu2204
+          - ubuntu2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
           - "3.12"
           - "3.13"
         ansible:
-          - 6
-          - 7
-          - 8
           - 9
           - 10
           - 11
@@ -63,20 +60,6 @@ jobs:
         exclude:
           - python: "3.10"
             ansible: 11
-          - python: "3.11"
-            ansible: 6
-          - python: "3.12"
-            ansible: 6
-          - python: "3.12"
-            ansible: 7
-          - python: "3.12"
-            ansible: 8
-          - python: "3.13"
-            ansible: 6
-          - python: "3.13"
-            ansible: 7
-          - python: "3.13"
-            ansible: 8
           - python: "3.13"
             ansible: 9
           - python: "3.13"
@@ -101,7 +84,7 @@ jobs:
           # https://github.com/docker/docker-py/issues/3113
           urllib3<2.0
           # https://github.com/ansible-community/molecule-plugins/issues/256
-          requests<2.32.0
+          #requests<2.32.0
           EOF
           echo "REQS_HASH=$(sha256sum test-requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,18 @@ jobs:
           ansible-lint
 
   test:
-    name: Test (${{ matrix.distro }})
+    name: Test (py${{ matrix.python }} ansible${{ matrix.ansible }} ${{ matrix.distro }})
     runs-on: ubuntu-latest
     needs:
       - lint
     strategy:
       matrix:
+        python:
+          - "3.12"
+          - "3.13"
+        ansible:
+          - 10
+          - 11
         distro:
           - ubuntu2004
           - ubuntu2204
@@ -57,12 +63,12 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python }}
 
       - name: Generate test-requirements.txt
         run: |
           cat <<EOF > test-requirements.txt
-          ansible
+          ansible==${{ matrix.ansible }}.*
           docker
           molecule-plugins[docker]
           EOF
@@ -72,7 +78,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ env.REQS_HASH }}
+          key: ${{ runner.os }}-py${{ matrix.python }}-ansible${{ matrix.ansible }}-${{ env.REQS_HASH }}
 
       - name: Install test dependencies
         run: pip3 install -r test-requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ name: CI
 "on":
   pull_request:
   push:
+    branches:
+      - "main"
   schedule:
     - cron: "46 14 * * 3"
   workflow_dispatch:

--- a/molecule/default/inventory/group_vars/all.yml
+++ b/molecule/default/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-docker_package_version: "5:24.0.7*"
+docker_package_version: "5:28*"
 
 docker_daemon_config:
   live-restore: false

--- a/molecule/default/inventory/host_vars/instance.yml
+++ b/molecule/default/inventory/host_vars/instance.yml
@@ -1,5 +1,5 @@
 ---
-docker_containerd_package_version: "1.6.24*"
+docker_containerd_package_version: "1.*"
 
 docker_host_daemon_config:
   log-opts:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,7 +16,7 @@
       changed_when: false
       failed_when: >-
         result.rc != 0 or
-        result.stdout is not match("5:24\.0\.7")
+        result.stdout is not match(docker_package_version)
 
     - name: Ensure specified containerd version is installed
       ansible.builtin.command: dpkg-query -f '${Version}' -W containerd.io

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -24,7 +24,7 @@
       changed_when: false
       failed_when: >-
         result.rc != 0 or
-        result.stdout is not match("1\.6\.24")
+        result.stdout is not match(docker_containerd_package_version)
 
     - name: Ensure Docker is running
       ansible.builtin.service:


### PR DESCRIPTION
The Python, Ansible, and Ubuntu versions targeted in CI are EOL, EOS, or about to be one of those. This PR (WIP) aims to bring them up to more recent versions. Starting purely additive; may eventually phase out older versions.