### PR TITLE
CI: improve with uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.6.3"
+          version: "0.6.4"
 
       - name: Set up Python 3
         uses: actions/setup-python@v5
@@ -84,7 +84,7 @@ jobs:
       - name: Install uv and set Python version
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.6.3"
+          version: "0.6.4"
           python-version: ${{ matrix.python }}
 
       - name: Set up Python 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Restore uv cache
         uses: actions/cache@v4
         with:
-          path: /tmp/.uv-cache
+          path: ${{ env.UV_CACHE_DIR }}
           key: uv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             uv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
           echo "REQS_HASH=$(sha256sum requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
 
       - name: Restore uv cache
-        id: restore-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.UV_CACHE_DIR }}
@@ -103,7 +102,6 @@ jobs:
             uv-${{ runner.os }}
 
       - name: Install test dependencies
-        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: uv pip install -r requirements.txt
 
       - name: Run pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,15 @@ jobs:
         with:
           path: metabrainz.docker
 
+      - name: Generate requirements.txt
+        run: |
+          cat <<EOF > requirements.txt
+          ansible==${{ matrix.ansible }}.*
+          docker
+          molecule-plugins[docker]
+          EOF
+          echo "REQS_HASH=$(sha256sum requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
+
       - name: Install uv and set Python version
         uses: astral-sh/setup-uv@v5
         with:
@@ -82,15 +91,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Generate requirements.txt
-        run: |
-          cat <<EOF > requirements.txt
-          ansible==${{ matrix.ansible }}.*
-          docker
-          molecule-plugins[docker]
-          EOF
-          echo "REQS_HASH=$(sha256sum requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
 
       - name: Restore uv cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.6.4"
-        run: |
-          echo "::remove-matcher owner=python::"
 
       - name: Set up Python 3
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ defaults:
   run:
     working-directory: metabrainz.docker
 
+env:
+  UV_SYSTEM_PYTHON: 1
+
 jobs:
   lint:
     name: Lint
@@ -24,13 +27,20 @@ jobs:
         with:
           path: metabrainz.docker
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.3"
+
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - name: Install dependencies
-        run: pip3 install yamllint ansible ansible-lint
+        run: |
+          uv tool install yamllint
+          uv tool install ansible-lint
 
       - name: Run lint
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.6.4"
+        run: |
+          echo "::remove-matcher owner=python::"
 
       - name: Set up Python 3
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
           echo "REQS_HASH=$(sha256sum requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
 
       - name: Restore uv cache
+        id: restore-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.UV_CACHE_DIR }}
@@ -102,6 +103,7 @@ jobs:
             uv-${{ runner.os }}
 
       - name: Install test dependencies
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: uv pip install -r requirements.txt
 
       - name: Run pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - lint
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache
     strategy:
       matrix:
         python:
@@ -70,31 +72,40 @@ jobs:
         with:
           path: metabrainz.docker
 
+      - name: Install uv and set Python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.3"
+          python-version: ${{ matrix.python }}
+
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Generate test-requirements.txt
+      - name: Restore uv cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.uv-cache
+          key: uv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+            uv-${{ runner.os }}
+
+      - name: Generate requirements.txt
         run: |
-          cat <<EOF > test-requirements.txt
+          cat <<EOF > requirements.txt
           ansible==${{ matrix.ansible }}.*
           docker
           molecule-plugins[docker]
           EOF
           echo "REQS_HASH=$(sha256sum test-requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
 
-      - name: Cache pip directory
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py${{ matrix.python }}-ansible${{ matrix.ansible }}-${{ env.REQS_HASH }}
-
       - name: Install test dependencies
-        run: pip3 install -r test-requirements.txt
+        run: uv pip install -r requirements.txt
 
       - name: Run pip freeze
-        run: pip3 freeze --all
+        run: uv pip freeze
 
       - name: Run tests
         run: molecule test
@@ -102,3 +113,6 @@ jobs:
           ANSIBLE_FORCE_COLOR: 1
           PY_COLORS: 1
           MOLECULE_DISTRO: ${{ matrix.distro }}
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,15 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Generate requirements.txt
+        run: |
+          cat <<EOF > requirements.txt
+          ansible==${{ matrix.ansible }}.*
+          docker
+          molecule-plugins[docker]
+          EOF
+          echo "REQS_HASH=$(sha256sum requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
+
       - name: Restore uv cache
         uses: actions/cache@v4
         with:
@@ -91,15 +100,6 @@ jobs:
           restore-keys: |
             uv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
             uv-${{ runner.os }}
-
-      - name: Generate requirements.txt
-        run: |
-          cat <<EOF > requirements.txt
-          ansible==${{ matrix.ansible }}.*
-          docker
-          molecule-plugins[docker]
-          EOF
-          echo "REQS_HASH=$(sha256sum test-requirements.txt | awk '{ print $1 }')" >> "$GITHUB_ENV"
 
       - name: Install test dependencies
         run: uv pip install -r requirements.txt


### PR DESCRIPTION
Building on the prior PR, this one aims to optimize CI tests by using [uv](https://docs.astral.sh/uv/) instead of raw pip. Now that we run linting + 12 checks per run, every bit of performance gains will help.

This PR starts with just the linting phase, and will eventually grow in scope towards the other checks.