### PR TITLE
ci: fix yamllint rules to align with ansible-lint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -15,7 +15,10 @@ rules:
   commas:
     max-spaces-after: -1
     level: error
-  comments: disable
+  # https://ansible.readthedocs.io/projects/lint/rules/yaml/#yamllint-configuration
+  # https://github.com/prettier/prettier/issues/6780
+  comments:
+    min-spaces-from-content: 1
   comments-indentation: disable
   document-start: disable
   empty-lines:
@@ -29,5 +32,9 @@ rules:
   new-line-at-end-of-file: disable
   new-lines:
     type: unix
+  # https://ansible.readthedocs.io/projects/lint/rules/yaml/#yamllint-configuration
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
   trailing-spaces: disable
   truthy: disable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,18 +11,18 @@ docker_package_policy_rc_d: 101
 docker_packages:
   - docker-ce
   - docker-ce-cli
-#docker_package_version: "5:24.0.*"
+# docker_package_version: "5:24.0.*"
 docker_package_pin_priority: 990
 docker_containerd_packages:
   - containerd.io
-#docker_containerd_package_version: "1.6.*"
+# docker_containerd_package_version: "1.6.*"
 docker_containerd_package_pin_priority: 990
 
 # stable, test or nightly
 docker_release_channel: stable
 docker_repository_key_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
 docker_repository_key_path: /usr/share/keyrings/docker.asc
-#docker_repository_key_checksum:
+# docker_repository_key_checksum:
 
 # configuration options
 docker_daemon_config_backup: false


### PR DESCRIPTION
ansible-lint currently complains about an incompatible `.yamllint` during action runs. This PR aligns the `.yamllint` as directed in warnings, following [ansible-lint documentation](https://ansible.readthedocs.io/projects/lint/rules/yaml/#yamllint-configuration).